### PR TITLE
feat(profile): show post details in PostedModal and support image viewer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -174,7 +174,7 @@ function App() {
             }
           />
           <Route
-            path="/profile/:id/activities"
+            path="/profile/activities"
             element={
               <ProtectedRoute>
                 {" "}

--- a/frontend/src/components/modal/PostedModal.jsx
+++ b/frontend/src/components/modal/PostedModal.jsx
@@ -1,10 +1,10 @@
 import Modal from "./Modal";
 import PostItem from "../feed/feed_content/PostItem";
 
-const PostedModal = ({ onClose }) => {
+const PostedModal = ({ onClose, post, onOpenImageViewer }) => {
   return (
     <Modal onClose={onClose} size="max-w-2xl">
-      <PostItem />
+      <PostItem post={post} onOpenImageViewer={onOpenImageViewer} />
     </Modal>
   );
 };

--- a/frontend/src/components/profile/Activity.jsx
+++ b/frontend/src/components/profile/Activity.jsx
@@ -29,7 +29,7 @@ const Activity = ({ id, onOpenPostedModal }) => {
 
             return (
               <div
-                onClick={onOpenPostedModal}
+                onClick={() => onOpenPostedModal(post)}
                 key={post._id}
                 className="bg-white rounded-xl shadow-sm hover:shadow-md min-w-[calc(50%-0.5rem)] max-w-[calc(50%-0.5rem)] flex-shrink-0 transition hover:bg-gray-100 cursor-pointer"
               >
@@ -90,7 +90,7 @@ const Activity = ({ id, onOpenPostedModal }) => {
       {!isLoading && posts.length > 0 && (
         <div className="text-center mt-4">
           <Link
-            to={`/profile/${id}/activities`}
+            to={`/profile/activities`}
             className="text-blue-500 font-medium hover:text-blue-700 transition"
           >
             Show all posts →

--- a/frontend/src/pages/all_activities_page/AllActivitiesPage.jsx
+++ b/frontend/src/pages/all_activities_page/AllActivitiesPage.jsx
@@ -1,30 +1,70 @@
-import { useParams } from "react-router-dom";
 import ProfileInfoCard from "../../components/common/ProfileInfoCard";
 import SuggestionCard from "../../components/common/SuggestionCard";
 import PostItem from "../../components/feed/feed_content/PostItem";
+import { useEffect, useState } from "react";
+import ImageViewerModal from "../../components/modal/ImageViewerModal.jsx";
+import { usePostStore } from "../../stores/usePostStore.js";
+import { useUserProfileStore } from "../../stores/useUserProfileStore.js";
 
 const AllActivities = () => {
-  // lấy id từ URL
-  const { id } = useParams();
-  console.log(id);
+  const { isLoading: profileLoading, userProfile } = useUserProfileStore();
+  const { isLoading, posts, getPostsByUser } = usePostStore();
+
+  useEffect(() => {
+    getPostsByUser();
+  }, [getPostsByUser]);
+
+  // gom tất cả data viewer vào 1 state
+  const [viewer, setViewer] = useState({
+    open: false,
+    images: [],
+    initialIndex: 0,
+    post: null,
+  });
+
+  // nhận images, index được click, và post
+  const openImageViewer = (images = [], initialIndex = 0, post = null) =>
+    setViewer({ open: true, images, initialIndex, post });
+
+  const closeImageViewer = () => setViewer((v) => ({ ...v, open: false }));
 
   return (
     <div className="container mx-auto max-w-7xl px-6 sm:px-6 lg:px-6 flex gap-6 mt-20 mb-6">
       {/* Left Sidebar */}
       <div className="hidden lg:block w-1/4">
-        <ProfileInfoCard />
+        <ProfileInfoCard isLoading={profileLoading} userProfile={userProfile} />
       </div>
 
       {/* Middle Feed */}
       <div className="flex-1 max-w-2xl">
         <h2 className="text-xl font-semibold mb-4 text-black">All Posted</h2>
-        <PostItem />
+        {isLoading ? (
+          <p className="text-gray-400 text-sm">Loading...</p>
+        ) : posts.length === 0 ? (
+          <p className="text-gray-400 text-sm">No activities yet</p>
+        ) : (
+          posts.map((post) => (
+            <div className="mb-4" key={post._id}>
+              <PostItem post={post} onOpenImageViewer={openImageViewer} />
+            </div>
+          ))
+        )}
       </div>
 
       {/* Right Sidebar */}
       <div className="hidden lg:block w-1/4">
         <SuggestionCard />
       </div>
+
+      {viewer.open && (
+        <ImageViewerModal
+          images={viewer.images}
+          initialIndex={viewer.initialIndex}
+          onClose={closeImageViewer}
+          title="Post photos"
+          loop
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/profile_page/ProfilePage.jsx
+++ b/frontend/src/pages/profile_page/ProfilePage.jsx
@@ -13,6 +13,7 @@ import { useUserProfileStore } from "../../stores/useUserProfileStore";
 import { useUserSkillStore } from "../../stores/useUserSkillStore";
 import { useUserExperienceStore } from "../../stores/useUserExperienceStore";
 import { usePostStore } from "../../stores/usePostStore";
+import ImageViewerModal from "../../components/modal/ImageViewerModal.jsx";
 
 const ProfilePage = () => {
   const { id } = useParams();
@@ -36,6 +37,23 @@ const ProfilePage = () => {
   const [openPostedModal, setOpenPostedModal] = useState(false);
 
   const [selectedExperience, setSelectedExperience] = useState(null);
+
+  // gom tất cả data viewer vào 1 state
+  const [viewer, setViewer] = useState({
+    open: false,
+    images: [],
+    initialIndex: 0,
+    post: null,
+  });
+
+  // dùng cho việc lưu post khi mở viewer
+  const [selectedPost, setSelectedPost] = useState(null);
+
+  // nhận images, index được click, và post
+  const openImageViewer = (images = [], initialIndex = 0, post = null) =>
+    setViewer({ open: true, images, initialIndex, post });
+
+  const closeImageViewer = () => setViewer((v) => ({ ...v, open: false }));
 
   const handleOpenInfomationModal = () => {
     setOpenInfomationModal(!openInfomationModal);
@@ -63,8 +81,14 @@ const ProfilePage = () => {
     setOpenMessageModal(!openMessageModal);
   };
 
-  const handleOpenPostedModal = () => {
-    setOpenPostedModal(!openPostedModal);
+  const handleOpenPostedModal = (post = null) => {
+    setSelectedPost(post);
+    setOpenPostedModal(true);
+  };
+
+  const handleClosePostedModal = () => {
+    setSelectedPost(null);
+    setOpenPostedModal(false);
   };
 
   return (
@@ -109,7 +133,23 @@ const ProfilePage = () => {
 
       {openMessageModal && <MessageModal onClose={handleOpenMessageModal} />}
 
-      {openPostedModal && <PostedModal onClose={handleOpenPostedModal} />}
+      {openPostedModal && (
+        <PostedModal
+          onClose={handleClosePostedModal}
+          post={selectedPost}
+          onOpenImageViewer={openImageViewer}
+        />
+      )}
+
+      {viewer.open && (
+        <ImageViewerModal
+          images={viewer.images}
+          initialIndex={viewer.initialIndex}
+          onClose={closeImageViewer}
+          title="Post photos"
+          loop
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- Pass selected post to PostedModal when clicking an activity
- Update PostedModal to render PostItem with post data
- Add ImageViewerModal integration for post images
- Fix route: `/profile/activities` instead of `/profile/:id/activities`
- Update AllActivitiesPage to load posts and support image viewer